### PR TITLE
Use separate trees for indexing 0s and 1s

### DIFF
--- a/include/quickbit.h
+++ b/include/quickbit.h
@@ -9,7 +9,7 @@ extern "C" {
 #include <stddef.h>
 #include <stdint.h>
 
-#define QUICKBIT_INDEX_LEN 16 + 128 * 16
+#define QUICKBIT_INDEX_LEN ((16 /* root */ + 128 * 16 /* children */) * 2)
 
 typedef uint8_t *quickbit_t;
 typedef uint8_t quickbit_index_t[QUICKBIT_INDEX_LEN];

--- a/src/quickbit.c
+++ b/src/quickbit.c
@@ -109,11 +109,7 @@ quickbit_index_of (const quickbit_t field, size_t field_len, bool value, int64_t
   if (index != NULL) {
     int64_t i = position / 16384;
 
-    while (i < 128 && quickbit_get_unchecked(index, quickbit_index_bit_offset(!value, i))) {
-      int64_t bit = i * 16384;
-
-      if (i == 127 || bit >= n) break;
-
+    while (i < 127 && quickbit_get_unchecked(index, quickbit_index_bit_offset(!value, i))) {
       i++;
     }
 
@@ -122,11 +118,7 @@ quickbit_index_of (const quickbit_t field, size_t field_len, bool value, int64_t
 
     if (position > k) j = (position - k) / 128;
 
-    while (j < 128 && quickbit_get_unchecked(index, quickbit_index_bit_offset(!value, i * 128 + j + 128))) {
-      int64_t bit = k + j * 128;
-
-      if (j == 127 || bit >= n) break;
-
+    while (j < 127 && quickbit_get_unchecked(index, quickbit_index_bit_offset(!value, i * 128 + j + 128))) {
       j++;
     }
 
@@ -154,11 +146,7 @@ quickbit_last_index_of (const quickbit_t field, size_t field_len, bool value, in
   if (index != NULL) {
     int64_t i = position / 16384;
 
-    while (i >= 0 && quickbit_get_unchecked(index, quickbit_index_bit_offset(!value, i))) {
-      int64_t bit = i * 16384;
-
-      if (i == 0 || bit >= n) break;
-
+    while (i > 0 && quickbit_get_unchecked(index, quickbit_index_bit_offset(!value, i))) {
       i--;
     }
 
@@ -167,11 +155,7 @@ quickbit_last_index_of (const quickbit_t field, size_t field_len, bool value, in
 
     if (position < k) j = (k - position) / 128;
 
-    while (j >= 0 && quickbit_get_unchecked(index, quickbit_index_bit_offset(!value, i * 128 + j + 128))) {
-      int64_t bit = k + j * 128;
-
-      if (j == 0 || bit >= n) break;
-
+    while (j > 0 && quickbit_get_unchecked(index, quickbit_index_bit_offset(!value, i * 128 + j + 128))) {
       j--;
     }
 

--- a/test/get.c
+++ b/test/get.c
@@ -2,7 +2,7 @@
 
 #include "../include/quickbit.h"
 
-#define field_len 1 << 18
+#define field_len (1 << 18)
 
 int
 main () {

--- a/test/index-of-indexed.c
+++ b/test/index-of-indexed.c
@@ -2,7 +2,7 @@
 
 #include "../include/quickbit.h"
 
-#define field_len 1 << 18
+#define field_len (1 << 18)
 
 int
 main () {

--- a/test/index-of.c
+++ b/test/index-of.c
@@ -2,7 +2,7 @@
 
 #include "../include/quickbit.h"
 
-#define field_len 1 << 18
+#define field_len (1 << 18)
 
 int
 main () {

--- a/test/index-update-sweep.c
+++ b/test/index-update-sweep.c
@@ -3,7 +3,7 @@
 
 #include "../include/quickbit.h"
 
-#define field_len 1 << 18
+#define field_len (1 << 18)
 
 int
 main () {

--- a/test/index-update.c
+++ b/test/index-update.c
@@ -2,7 +2,7 @@
 
 #include "../include/quickbit.h"
 
-#define field_len 1 << 18
+#define field_len (1 << 18)
 
 int
 main () {

--- a/test/last-index-of-indexed.c
+++ b/test/last-index-of-indexed.c
@@ -2,7 +2,7 @@
 
 #include "../include/quickbit.h"
 
-#define field_len 1 << 18
+#define field_len (1 << 18)
 
 int
 main () {

--- a/test/last-index-of.c
+++ b/test/last-index-of.c
@@ -2,7 +2,7 @@
 
 #include "../include/quickbit.h"
 
-#define field_len 1 << 18
+#define field_len (1 << 18)
 
 int
 main () {

--- a/test/set.c
+++ b/test/set.c
@@ -2,7 +2,7 @@
 
 #include "../include/quickbit.h"
 
-#define field_len 1 << 18
+#define field_len (1 << 18)
 
 int
 main () {


### PR DESCRIPTION
This simplifies the indexing operations quite significantly and also means that we no longer need to peek the field, making it possible to perform the optimisation outlined in #2.